### PR TITLE
feat: add noop PipelineRun with on-cel precedence warning

### DIFF
--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: main
     pipelinesascode.tekton.dev/on-event: pull_request
-    pipelinesascode.tekton.dev/on-cel: |
+    pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
 spec:
   pipelineSpec:

--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: scratchmyback-pull-request
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+    pipelinesascode.tekton.dev/on-cel: |
+      event == "pull_request"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noop-task
+        displayName: Task with no effect
+        taskSpec:
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0


### PR DESCRIPTION
- add PipelineRun triggered by event == "pull_request" using on-cel annotation
- document precedence of on-cel over on-event and on-target-branch annotations
- warn users via log and Kubernetes event when on-cel is set and others are ignored