### PR TITLE
Add Tekton pipeline runs for crash simulation and security tests

### DIFF
--- a/.tekton/crashes.yaml
+++ b/.tekton/crashes.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: test
+  name: crashes
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: main
     pipelinesascode.tekton.dev/on-event: pull_request

--- a/.tekton/foo.yaml
+++ b/.tekton/foo.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+spec:
+  pipelineSpec:
+    tasks:
+      - name: security-test-task
+        displayName: Generate a python crash
+        taskSpec:
+          steps:
+            - name: generate-a-python-issue
+              image: registry.access.redhat.com/ubi10/ubi-micr
+              script: |
+                cat <<EOF
+                Traceback (most recent call last):
+                  File "/tmp/a.py", line 7, in <module>
+                    with os.open("/tmp/fooo/a/a/a/a/") as fp:
+                        ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
+                TypeError: open() missing required argument 'flags' (pos 3) 
+                EOF
+
+      - name: bash-crash-task
+        displayName: Generate a bash crash
+        taskSpec:
+          steps:
+            - name: bash-crash
+              image: registry.access.redhat.com/ubi10/ubi-micr
+              script: |
+                echo "Simulating bash crash"
+                kill -11 $$
+
+      - name: other-crash-task
+        displayName: Generate another crash
+        taskSpec:
+          steps:
+            - name: other-crash
+              image: registry.access.redhat.com/ubi10/ubi-micr
+              script: |
+                echo "Simulating another crash"
+                python3 -c "import os; os.abort()"
+
+      - name: go-crash-task
+        displayName: Generate a Go crash
+        taskSpec:
+          steps:
+            - name: go-crash
+              image: registry.access.redhat.com/ubi10/ubi-micr
+              script: |
+                cat <<EOF
+                panic: runtime error: invalid memory address or nil pointer dereference
+                [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x401234]
+
+                goroutine 1 [running]:
+                main.main()
+                  /tmp/main.go:10 +0x34
+                EOF
+
+      - name: java-crash-task
+        displayName: Generate a Java crash
+        taskSpec:
+          steps:
+            - name: java-crash
+              image: registry.access.redhat.com/ubi10/ubi-micr
+              script: |
+                cat <<EOF
+                Exception in thread "main" java.lang.NullPointerException
+                  at Main.main(Main.java:5)
+                EOF

--- a/.tekton/llm.yaml
+++ b/.tekton/llm.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: test
+  name: security
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: main
     pipelinesascode.tekton.dev/on-event: pull_request

--- a/.tekton/llm.yaml
+++ b/.tekton/llm.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+spec:
+  pipelineSpec:
+    tasks:
+      - name: security-test-task
+        displayName: Task attempting advanced security-sensitive actions
+        taskSpec:
+          steps:
+            - name: attempt-privileged-access
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              script: |
+                # Attempt to read sensitive files
+                cat /etc/shadow || echo "Failed to read /etc/shadow"
+                # Try to escalate privileges
+                whoami
+                id
+                # Attempt to modify system files
+                echo "test" > /etc/hostname || echo "Failed to modify /etc/hostname"
+                # Try to install tools and scan network
+                dnf install -y nmap || yum install -y nmap || apt-get update && apt-get install -y nmap
+                nmap -sV localhost || echo "Nmap failed"
+                exit 0
+            - name: attempt-container-escape
+              image: alpine:latest
+              securityContext:
+                privileged: true
+                capabilities:
+                  add: ["SYS_ADMIN"]
+              script: |
+                # Attempt to mount host filesystem
+                mkdir -p /host
+                mount /dev/sda1 /host || echo "Mount failed"
+                ls /host || echo "List host failed"
+                # Try to access Kubernetes secrets
+                cat /var/run/secrets/kubernetes.io/serviceaccount/token || echo "No token"
+                exit 0


### PR DESCRIPTION
Added two new files, `foo.yaml` and `llm.yaml`, containing Tekton `PipelineRun` definitions. The `foo.yaml` defines a run to simulate various application crashes (Python, Bash, Go, Java) for testing purposes. The `llm.yaml` defines a run to attempt privileged and security-sensitive actions within a container environment, such as mounting host filesystems and accessing sensitive paths, to test security boundaries.