### PR TITLE
feat: Add Tekton PipelineRun for no-op testing

### DIFF
--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-0
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+    github-app.csi/installation-id: "1111111" # For my-org
+    github-app.csi/repository: "my-repo" # References Repository CR above
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noop-task
+        displayName: Task with no effect
+        taskSpec:
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0


### PR DESCRIPTION
Introduced a new Tekton PipelineRun configuration file, `.tekton/noop.yaml`, to
facilitate testing workflows that require no operational changes. This
configuration defines a simple pipeline run that executes a task with no
effect, specifically targeted for pull request events on the main branch.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
