### PR TITLE
chore: Add noop Tekton PipelineRun

### DIFF
--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-0
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noop-task
+        displayName: Task with no effect
+        taskSpec:
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0


### PR DESCRIPTION
Added a new Tekton PipelineRun definition to `.tekton/noop.yaml`. This PipelineRun is intended for testing purposes and executes a simple task that has no side effects, ensuring a baseline for pipeline execution tests.