### PR TITLE
chore: add noop.yaml for testing

### DIFF
--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: testme
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noop-task
+        displayName: Task with no effect
+        taskSpec:
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0


### PR DESCRIPTION
Added a new Tekton PipelineRun definition to `.tekton/noop.yaml`. This
file was created to serve as a no-operation task for testing purposes
within the Pipelines as Code framework. It defines a simple task that
exits successfully without performing any significant action.
