### PR TITLE
chore: add noop Tekton PipelineRun

### DIFF
--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-0
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noop-task
+        taskSpec:
+          liinuxBar:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0


### PR DESCRIPTION
Added a new Tekton PipelineRun definition for a no-operation task. This file was created to serve as a placeholder or a test resource within the Tekton CI/CD environment.