### PR TITLE
chore: add noop pipeline for testing

### DIFF
--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-0
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: main
+    pipelinesascode.tekton.dev/on-event: pull_request
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noop-task
+        displayName: Task with no effect
+        taskSpec:
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0

--- a/.tekton/noop.yaml
+++ b/.tekton/noop.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: main
     pipelinesascode.tekton.dev/on-event: pull_request
+    pipelinesascode.tekton.dev/task: "git-clone"
 spec:
   pipelineSpec:
     tasks:


### PR DESCRIPTION
Introduced a dummy PipelineRun to verify that the Tekton integration triggers correctly on pull requests targeting the main branch.